### PR TITLE
Correct line height for FAQ titles

### DIFF
--- a/themes/orcid-outreach-pro/style.css
+++ b/themes/orcid-outreach-pro/style.css
@@ -1259,6 +1259,7 @@ summary::-webkit-details-marker {
 	border-bottom: var(--medium) solid var(--ui-background);
 	color: var(--copy-dark);
 	cursor: pointer;
+	line-height: 1.2!important;
 	padding: var(--space-double) var(--space-double) var(--space-double) var(--space-quint)!important;
 }
 

--- a/themes/orcid-outreach-pro/style.css
+++ b/themes/orcid-outreach-pro/style.css
@@ -1259,6 +1259,7 @@ summary::-webkit-details-marker {
 	border-bottom: var(--medium) solid var(--ui-background);
 	color: var(--copy-dark);
 	cursor: pointer;
+	font-size: 16px!important;
 	line-height: 1.2!important;
 	padding: var(--space-double) var(--space-double) var(--space-double) var(--space-quint)!important;
 }


### PR DESCRIPTION
Make sure FAQ titles that wrap on to multiple lines have a sensible line height set.

This fixes the display oddity on https://info.orcid.org/documentation/integration-and-api-faq/#easy-faq-2721 where FAQ titles have a line height of 0 and look all crunched up. 